### PR TITLE
fix(ci): install web/ deps before jest runs (#122 story 1)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -87,6 +87,12 @@ jobs:
         # npm install (not npm ci) — repo has no committed lock file (#120 story 2)
         run: npm install
 
+      - name: Install web/ dependencies
+        # jest.config.js roots + collectCoverageFrom reference web/src/**, so the
+        # web/ subdirectory needs its own deps resolved for ts-jest + coverage to
+        # succeed (#122 story 1). web/package.json is a separate npm project.
+        run: cd web && npm install
+
       - name: Run Integration Tests - Cross-App
         run: npm test -- tests/integration/cross-app.test.ts --coverage --coverageReporters=json --coverageReporters=text
         env:
@@ -234,6 +240,12 @@ jobs:
         # npm install (not npm ci) — repo has no committed lock file (#120 story 2)
         run: npm install
 
+      - name: Install web/ dependencies
+        # jest.config.js roots + collectCoverageFrom reference web/src/**, so the
+        # web/ subdirectory needs its own deps resolved for ts-jest + coverage to
+        # succeed (#122 story 1). web/package.json is a separate npm project.
+        run: cd web && npm install
+
       - name: Run Contract Tests
         run: npm test -- tests/contracts --coverage
 
@@ -267,6 +279,12 @@ jobs:
       - name: Install dependencies
         # npm install (not npm ci) — repo has no committed lock file (#120 story 2)
         run: npm install
+
+      - name: Install web/ dependencies
+        # jest.config.js roots + collectCoverageFrom reference web/src/**, so the
+        # web/ subdirectory needs its own deps resolved for ts-jest + coverage to
+        # succeed (#122 story 1). web/package.json is a separate npm project.
+        run: cd web && npm install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary

First child story of #122 `ci-test-surface-repair`. Workflow-only fix. jest.config.js declares `roots: ['<rootDir>/tests', '<rootDir>/web/src']` and `collectCoverageFrom: ['web/src/**/*.{ts,tsx}']`, so ts-jest needs web/'s deps resolvable at test time. Before this PR, CI only installed root-level dev tooling and hit `Cannot find module 'react'` on every coverage collection pass.

Adds one new step after each existing `Install dependencies` step in the 3 Node jobs (integration-tests matrix, contract-tests, e2e-journey-tests):

```yaml
- name: Install web/ dependencies
  run: cd web && npm install
```

## Expected cascade

- **Integration Tests (18.x + 20.x):** coverage-collection errors disappear. The one real assertion failure in `cross-app.test.ts` probably persists — that's #122 story 2.
- **Contract Tests:** the 3 suites (`multi_robot.test.ts`, `artbot.test.ts`, `ui-animations.test.ts`) that import from `web/src/components/*` should compile. If they still fail on non-missing-react TypeScript errors (e.g. existing TS7031 / TS2554 in `EmailAccounts.tsx`), those are further scope (story 2b within #122).
- **E2E Journey Tests:** unchanged — still blocked on #122 story 3 (mbot-companion CI-safe mode).
- **Patent Claim Verification:** unchanged — PASS.

## Closes / references

- Part of #122 (epic: CI test-surface repair). Closes story 1 on merge.
- Multicheck goal packet [G-003]; pre-flight [S-020] / [R-025] accept.

## Test plan

- [x] `gh pr checks` on this PR will determine success. Patent Claim Verification stays PASS; 2+ of the 4 previously-failing Node jobs move toward PASS.
- [ ] After merge: rebase `feat/gavalas-p0`, re-run PR #118 CI, confirm progression.

Review by a second Claude Opus 4.7 session (same-model pairing per session `multicheck/details.md`).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)