### PR TITLE
diag(ci): switch Playwright webServer to web/server.js (#122 story 3 diagnostic)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'cargo run --bin mbot-companion',
+    command: 'cd web && node server.js',
     url: 'http://127.0.0.1:3000',
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Summary — DIAGNOSTIC PR, DO NOT MERGE EXCEPT ON GREEN-CI OUTCOME

**This is an investigation probe authorized under multicheck `[R-033]` option (β), not a final Story 3 fix.** See `multicheck/agentchat.md` [S-026] for the scope-blowup analysis that led here.

## The 1-line change

`playwright.config.ts` line 41:

```diff
- command: 'cargo run --bin mbot-companion',
+ command: 'cd web && node server.js',
```

## Why

`cargo run --bin mbot-companion` runs a Rust CLI that talks to robot hardware; it does NOT serve the dashboard on port 3000 — which is why E2E Journey Tests have been failing at webServer startup with exit 101.

`web/server.js` IS the actual port-3000 dashboard server (express + static serving). It MAY serve cleanly without a live mbot-companion child process; it MAY NOT. This PR finds out.

## Expected outcomes (each implies a different follow-up)

| # | Outcome | Implication |
|---|---------|-------------|
| 1 | E2E passes green | 1-line surgical fix actually closes Story 3; reviewer authorizes merge |
| 2 | E2E reaches dashboard but times out on `getByTestId('status-ready')` | Dashboard serves fine but the WebSocket-to-companion-simulator layer is the missing piece; operator decides on full Story 3 scope |
| 3 | E2E fails at page load | `web/server.js` has its own runtime issue (missing build artefacts, crash on startup, etc.); operator decides on 'web/ build step in CI' scope expansion |

## Do NOT merge

Per `[R-033]` constraint, this PR stays open after CI returns. Only on outcome #1 will I post a ready-for-review requesting merge authorization. Otherwise the PR is evidence for operator's return-state assessment.

## Multicheck trail

- Story 3 investigation: `[S-026]` STATE: blocked (scope-blowup analysis)
- Reviewer decision: `[R-033]` option (β) diagnostic push authorized, DO NOT MERGE
- HITL delegation active per `[H-006]` (operator offline overnight)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)